### PR TITLE
Support for prepared statements

### DIFF
--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -72,7 +72,7 @@ function SQL:prepareStatement(query, values)
 		if value == nil then
 			newQuery = newQuery .. "NULL"
 		elseif type(value) == "string" then
-			newQuery = newQuery .. sql.SQLStr(value)
+			newQuery = newQuery .. self:Escape(value)
 		elseif type(value) == "boolean" then
 			newQuery = newQuery .. (value and "1" or "0")
 		else

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -78,12 +78,9 @@ function SQL:prepareStatement(query, values)
 		elseif tonumber(value) then
 			newQuery = newQuery .. value
 		else
-			PulsarLib.Logging.Fatal("Invalid value type for prepared statement, expected nil, string, boolean or number, got " .. type(value))
-			debug.traceback()
+			PulsarLib.Logging.Fatal("Invalid value type for prepared statement, expected nil, string, boolean or number, got " .. type(value) .. "\n" .. debug.traceback())
 			return
 		end
-
-		error()
 
 		last = stop
 		i = i + 1

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -78,9 +78,12 @@ function SQL:prepareStatement(query, values)
 		elseif tonumber(value) then
 			newQuery = newQuery .. value
 		else
-			ErrorNoHaltWithStack("Invalid value type for prepared statement, expected nil, string, boolean or number, got " .. type(value))
+			PulsarLib.Logging.Fatal("Invalid value type for prepared statement, expected nil, string, boolean or number, got " .. type(value))
+			debug.traceback()
 			return
 		end
+
+		error()
 
 		last = stop
 		i = i + 1

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -124,7 +124,7 @@ function SQL:RawQuery(query, onSuccess, onError)
 
 		local x = string.Split(query, "\n")
 		for _, line in ipairs(x) do
-			PulsarStore.Logging.Debug(line)
+			PulsarLib.Logging.Debug(line)
 		end
 		query = sql.Query(query)
 
@@ -176,7 +176,7 @@ function SQL:PreparedQuery(query, values, onSuccess, onError)
 
 		local x = string.Split(query, "\n")
 		for _, line in ipairs(x) do
-			PulsarStore.Logging.Debug(line)
+			PulsarLib.Logging.Debug(line)
 		end
 
 		query = SQL:prepareStatement(query, values)

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -195,7 +195,7 @@ end
 
 function SQL:Escape(str)
 	if self.Details.UsingMySQL then
-		return self.Connection:escape(str)
+		return "'" .. self.Connection:escape(str) .. "'"
 	else
 		return sql.SQLStr(str)
 	end

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -75,8 +75,11 @@ function SQL:prepareStatement(query, values)
 			newQuery = newQuery .. self:Escape(value)
 		elseif type(value) == "boolean" then
 			newQuery = newQuery .. (value and "1" or "0")
-		else
+		elseif tonumber(value) then
 			newQuery = newQuery .. value
+		else
+			ErrorNoHaltWithStack("Invalid value type for prepared statement, expected nil, string, boolean or number, got " .. type(value))
+			return
 		end
 
 		last = stop

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -156,7 +156,7 @@ function SQL:PreparedQuery(query, values, onSuccess, onError)
 			onError(err)
 		end
 
-		for k, v in pairs(values or {}) do
+		for k, v in ipairs(values or {}) do
 			if type(v) == "string" then
 				queryObj:setString(k, v)
 			elseif type(v) == "number" then

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -99,7 +99,7 @@ local sqliteReplaces = {
 local emptyFunction = function() end
 
 function SQL:RawQuery(query, onSuccess, onError)
-	onSuiccess = onSuccess or emptyFunction
+	onSuccess = onSuccess or emptyFunction
 	onError = onError or emptyFunction
 
 	if self.Details.UsingMySQL then
@@ -139,7 +139,7 @@ function SQL:RawQuery(query, onSuccess, onError)
 end
 
 function SQL:PreparedQuery(query, values, onSuccess, onError)
-	onSuiccess = onSuccess or emptyFunction
+	onSuccess = onSuccess or emptyFunction
 	onError = onError or emptyFunction
 
 	if self.Details.UsingMySQL then

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -2,7 +2,7 @@ PulsarLib = PulsarLib or {}
 PulsarLib.SQL = PulsarLib.SQL or setmetatable({
 	stored = {}
 }, {__index = PulsarLib})
- 
+
 local SQL = PulsarLib.SQL
 
 file.CreateDir("pulsarlib")
@@ -44,7 +44,7 @@ end
 
 function SQL:ConnectSQLite()
 	hook.Run("PulsarLib.SQL.Connected")
-end 
+end
 
 function SQL:Connect()
 	self:FetchDetails()

--- a/lua/pulsar_lib/core/sql/sv_sql.lua
+++ b/lua/pulsar_lib/core/sql/sv_sql.lua
@@ -4,6 +4,7 @@ PulsarLib.SQL = PulsarLib.SQL or setmetatable({
 }, {__index = PulsarLib})
 
 local SQL = PulsarLib.SQL
+local logger = PulsarLib.Logging:Get("Database")
 
 file.CreateDir("pulsarlib")
 
@@ -30,12 +31,12 @@ function SQL:ConnectMySQL()
 	self.Connection = mysqloo.connect(self.Details.Hostname, self.Details.Username, self.Details.Password, self.Details.Database, self.Details.Port)
 
 	self.Connection.onConnected = function()
-		PulsarLib.Logging.Info("Successfully connected to mysql database")
+		logger.Info("Successfully connected to mysql database")
 		hook.Run("PulsarLib.SQL.Connected")
 	end
 
 	self.Connection.onConnectionFailed = function(_, err)
-		PulsarLib.Logging.Error("Failed to connect to mysql database: " .. err)
+		logger.Error("Failed to connect to mysql database: " .. err)
 		hook.Run("PulsarLib.SQL.ConnectionFailed")
 	end
 
@@ -78,7 +79,7 @@ function SQL:prepareStatement(query, values)
 		elseif tonumber(value) then
 			newQuery = newQuery .. value
 		else
-			PulsarLib.Logging.Fatal("Invalid value type for prepared statement, expected nil, string, boolean or number, got " .. type(value) .. "\n" .. debug.traceback())
+			logger.Fatal("Invalid value type for prepared statement, expected nil, string, boolean or number, got " .. type(value) .. "\n" .. debug.traceback())
 			return
 		end
 
@@ -113,9 +114,9 @@ function SQL:RawQuery(query, onSuccess, onError)
 		end
 
 		queryObj.onError = function(_, err)
-			PulsarLib.Logging.Fatal("Raw MySQL query failed!")
-			PulsarLib.Logging.Fatal(err)
-			PulsarLib.Logging.Fatal(query)
+			logger.Fatal("Raw MySQL query failed!")
+			logger.Fatal(err)
+			logger.Fatal(query)
 			onError(err)
 		end
 
@@ -127,13 +128,13 @@ function SQL:RawQuery(query, onSuccess, onError)
 
 		local x = string.Split(query, "\n")
 		for _, line in ipairs(x) do
-			PulsarLib.Logging.Debug(line)
+			logger.Debug(line)
 		end
 		query = sql.Query(query)
 
 		if query == false then
-			PulsarLib.Logging.Fatal("SQL query failed!")
-			PulsarLib.Logging.Fatal(sql.LastError())
+			logger.Fatal("SQL query failed!")
+			logger.Fatal(sql.LastError())
 			onError(sql.LastError())
 		else
 			onSuccess(query)
@@ -153,9 +154,9 @@ function SQL:PreparedQuery(query, values, onSuccess, onError)
 		end
 
 		queryObj.onError = function(_, err)
-			PulsarLib.Logging.Fatal("Prepared MySQL query failed!")
-			PulsarLib.Logging.Fatal(err)
-			PulsarLib.Logging.Fatal(SQL:prepareStatement(query, values))
+			logger.Fatal("Prepared MySQL query failed!")
+			logger.Fatal(err)
+			logger.Fatal(SQL:prepareStatement(query, values))
 			onError(err)
 		end
 
@@ -179,7 +180,7 @@ function SQL:PreparedQuery(query, values, onSuccess, onError)
 
 		local x = string.Split(query, "\n")
 		for _, line in ipairs(x) do
-			PulsarLib.Logging.Debug(line)
+			logger.Debug(line)
 		end
 
 		query = SQL:prepareStatement(query, values)
@@ -187,8 +188,8 @@ function SQL:PreparedQuery(query, values, onSuccess, onError)
 		query = sql.Query(query)
 
 		if query == false then
-			PulsarLib.Logging.Fatal("SQL query failed!")
-			PulsarLib.Logging.Fatal(sql.LastError())
+			logger.Fatal("SQL query failed!")
+			logger.Fatal(sql.LastError())
 			onError(sql.LastError())
 		else
 			onSuccess(query)


### PR DESCRIPTION
How to use:

```lua
PulsarLib.SQL:PreparedQuery("SELECT 1 = ? WHERE stuff = ?", { 1 },
    function()
        print("ok")
    end
)
```

every ? in the query will get replaced by the value in the second argument (in the order it was given)
if there are more ? in the query than there are values in the second argument it will set everything that is missing to "NULL" in the query, this basicly translates "nil" to "NULL" for the database

the given example would result in this query:
`SELECT 1 = 1 WHERE stuff = NULL`


for sqlite it will use the fallback "prepareStatement" function to make it also work with sqlite, just without the actual prepared part

this merge request also fixes a small error related to logging